### PR TITLE
Make jenkins URL param work with and without trailing slash

### DIFF
--- a/jenkins/job_client.rb
+++ b/jenkins/job_client.rb
@@ -9,7 +9,7 @@ module Jenkins
     INTERVAL_SECONDS = 10
 
     def initialize(args)
-      @jenkins_url = args['INPUT_JENKINS_URL']
+      @jenkins_url = args['INPUT_JENKINS_URL'].chomp('/')
       @jenkins_user = args['INPUT_JENKINS_USER']
       @jenkins_token = args['INPUT_JENKINS_TOKEN']
       @job_name = args['INPUT_JOB_NAME']
@@ -43,7 +43,7 @@ module Jenkins
     def queue_job(crumb, job_name, job_params)
       query_string = ''
       job_params&.each_pair { |k, v| query_string +="#{k}=#{v}&" }
-      job_queue_url = "#{jenkins_url}job/#{job_name}/buildWithParameters?#{query_string}".chop
+      job_queue_url = "#{jenkins_url}/job/#{job_name}/buildWithParameters?#{query_string}".chop
       queue_response = perform_request(job_queue_url, :post, params: { 'token': jenkins_token }, headers: {'Jenkins-Crumb': crumb})
       queue_item_location = queue_response.headers[:location]
       queue_item_location


### PR DESCRIPTION
When jenkins_url param is passed without the trailing slash, the action fails to connect to `https://jenkins-build.toptal.netjobs`, that's expected as it should be `https://jenkins-build.toptal.net/jobs`

Make sure the job works no matter if the passed param ends with a slash or not