### PR TITLE
Add async option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,29 +27,4 @@ jobs:
           async: false # Default to false (optional)
 ```
 
-It's also possible trigger a Jenkins job and don't wait for it to finish with the `async` option
-
-```
-name: Your GHA
-on:
-  pull_request:
-    types: [opened, synchronize]
-
-jobs:
-  your_job_name:
-    name: Trigger Jenkins Job asynchronously
-    runs-on: ubuntu-latest
-    steps:
-      - name: Trigger your-awesome-job-name job
-        id: trigger-jenkins-job
-        uses: toptal/jenkins-job-trigger-action@master
-        with:
-          jenkins_url: "https://your.jenkins.url/"
-          jenkins_user: ${{ secrets.JENKINS_USER }}
-          jenkins_token: ${{ secrets.JENKINS_TOKEN }}
-          job_name: "the-name-of-your-jenkins-job"
-          async: true
-          
-      - name: Debug
-        run: echo "A job has been scheduled, see progress at ${{steps.trigger-jenkins-job.outputs.jenkins_job_url}}"
-```
+It's also possible to trigger a Jenkins job without waiting for it to finish by setting async option as true

--- a/README.md
+++ b/README.md
@@ -24,4 +24,32 @@ jobs:
           job_name: "the-name-of-your-jenkins-job"
           job_params: '{"param_1":"value_1", "param_2":"value_2"}'
           job_timeout: "3600" # Default 30 sec. (optional)
+          async: false # Default to false (optional)
+```
+
+It's also possible trigger a Jenkins job and don't wait for it to finish with the `async` option
+
+```
+name: Your GHA
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  your_job_name:
+    name: Trigger Jenkins Job asynchronously
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger your-awesome-job-name job
+        id: trigger-jenkins-job
+        uses: toptal/jenkins-job-trigger-action@master
+        with:
+          jenkins_url: "https://your.jenkins.url/"
+          jenkins_user: ${{ secrets.JENKINS_USER }}
+          jenkins_token: ${{ secrets.JENKINS_TOKEN }}
+          job_name: "the-name-of-your-jenkins-job"
+          async: true
+          
+      - name: Debug
+        run: echo "A job has been scheduled, see progress at ${{steps.trigger-jenkins-job.outputs.jenkins_job_url}}"
 ```

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,13 @@ inputs:
     description: 'Jenkins job timeout period. Default 30 seconds'
     required: false
     default: '30'
+  async:
+    description: 'Set to true if you want to just trigger the job without waiting for it to finish'
+    required: false
+    default: false
+outputs:
+  jenkins_job_url:
+    description: 'URL to the job details'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/jenkins/job_client.rb
+++ b/jenkins/job_client.rb
@@ -3,7 +3,7 @@ require 'json'
 module Jenkins
   class JobClient
 
-    attr_reader :jenkins_url, :jenkins_user, :jenkins_token, :job_name, :job_params, :job_timeout
+    attr_reader :async_mode, :jenkins_url, :jenkins_user, :jenkins_token, :job_name, :job_params, :job_timeout
 
     DEFAULT_TIMEOUT = 30
     INTERVAL_SECONDS = 10
@@ -13,6 +13,7 @@ module Jenkins
       @jenkins_user = args['INPUT_JENKINS_USER']
       @jenkins_token = args['INPUT_JENKINS_TOKEN']
       @job_name = args['INPUT_JOB_NAME']
+      @async_mode = args['INPUT_ASYNC']
       @job_params = JSON.parse(args['INPUT_JOB_PARAMS'])
       @job_timeout = args['INPUT_JOB_TIMEOUT'] || DEFAULT_TIMEOUT
     end
@@ -21,7 +22,11 @@ module Jenkins
       crumb = get_crumb
       queue_item_location = queue_job(crumb, job_name, job_params)
       job_run_url = get_job_run_url(queue_item_location, job_timeout)
+      puts "::set-output name=jenkins_job_url::#{job_run_url}"
       puts "Job run URL: #{job_run_url}"
+
+      exit(0) if @async_mode
+
       job_progress(job_run_url, job_timeout)
       exit(0)
     end


### PR DESCRIPTION
Make it possible to schedule a job in a fire and forget mode. We need that to trigger features tests and we don't want to spend 1h on GHA just waiting for the results.

Tested in https://github.com/toptal/talent-portal-frontend/pull/2485

```yml
name: CI

on:
  push:
    branches: [master]

jobs:
  feature_tests:
    name: 'Run feature tests'
    runs-on: ubuntu-latest
    steps:
      - name: Trigger talent-portal-staging-deployment job
        id: trigger-feature-tests
        uses: toptal/jenkins-job-trigger-action@3fe0f6f8f28795c59f5f3a314f713fa6201596e3
        with:
          jenkins_url: 'https://jenkins-features.toptal.net/'
          jenkins_user: toptal-bot
          jenkins_token: ${{ secrets.TOPTAL_BOT_JENKINS_FEATURES_TOKEN }}
          job_name: 'talent-portal/job/talent-portal-master-features-leader'
          job_params: '{"GIT_COMMIT":"${{ github.event.pull_request.head.sha }}"}'
          job_timeout: 120 # 2 minutes
          async: true

      - name: Debug
        run: echo ${{steps.trigger-feature-tests.outputs.jenkins_job_url}}
```