### PR TITLE
Change url of jenkins in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ jobs:
       - name: Trigger your-awesome-job-name job
         uses: toptal/jenkins-job-trigger-action@master
         with:
-          jenkins_url: "https://your.jenkins.url/"
+          jenkins_url: "https://jenkins-deployment.toptal.net/"
           jenkins_user: ${{ secrets.JENKINS_USER }}
           jenkins_token: ${{ secrets.JENKINS_TOKEN }}
           job_name: "the-name-of-your-jenkins-job"


### PR DESCRIPTION
For us looks like in the future only 1 instance of Jenkins will be responsible for deployments (https://toptal-core.atlassian.net/wiki/spaces/CI/pages/2128151554/Kubernetes+CI+guidelines), so probably makes sense to have it only specified in docs.