### PR TITLE
fix: job url output

### DIFF
--- a/jenkins/job_client.rb
+++ b/jenkins/job_client.rb
@@ -23,8 +23,12 @@ module Jenkins
     def call
       queue_item_location = queue_job(job_name, job_params)
       job_run_url = get_job_run_url(queue_item_location, job_timeout)
-      puts "echo 'jenkins_job_url=#{job_run_url}' >> $GITHUB_OUTPUT"
+      output_file = ENV["GITHUB_OUTPUT"]
+      open(output_file, 'a') do |f|
+        f << "jenkins_job_url=#{job_run_url}"
+      end
       puts "Job run URL: #{job_run_url}"
+      
 
       if @async_mode
         puts "Stopping at the triggering step since the async option is enabled"


### PR DESCRIPTION
This PR fixes the `jenkins_job_url` missing output. https://github.com/toptal/jenkins-job-trigger-action/issues/11