### PR TITLE
update bundler version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,4 +27,4 @@ DEPENDENCIES
   rest-client
 
 BUNDLED WITH
-   2.2.17
+   2.6.2


### PR DESCRIPTION
Quickfix to avoid issues like the following:

```
#10 [6/6] RUN bundle install
  #10 0.321 Bundler 2.6.2 is running, but your lockfile was generated with 2.2.17. Installing Bundler 2.2.17 and restarting using that version.
  #10 0.943 Fetching gem metadata from [https://rubygems.org/.](https://rubygems.org/)
  #10 1.012 Fetching bundler 2.2.17
  #10 1.094 Installing bundler 2.2.17
  #10 1.301 /usr/local/bundle/gems/bundler-2.2.17/lib/bundler/vendor/thor/lib/thor/error.rb:105:in '<class:Thor>': uninitialized constant DidYouMean::SPELL_CHECKERS (NameError)
  #10 1.301
``` 